### PR TITLE
Uk/1031 insufficient stock in cart

### DIFF
--- a/config/initializers/user_class_extensions.rb
+++ b/config/initializers/user_class_extensions.rb
@@ -4,7 +4,7 @@ Spree::Core::Engine.config.to_prepare do
 
       # Override of spree method to ignore orders associated with account_invoices
       def last_incomplete_spree_order_with_ignoring_account_invoices
-        account_invoice_order_ids = account_invoices.pluck(:order_id)
+        account_invoice_order_ids = account_invoices.where('order_id IS NOT NULL').pluck(:order_id)
         return last_incomplete_spree_order_without_ignoring_account_invoices if account_invoice_order_ids.empty?
         spree_orders.incomplete.where("id NOT IN (?)", account_invoice_order_ids).order('created_at DESC').first
       end

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -6,54 +6,6 @@ feature "full-page cart", js: true do
   include ShopWorkflow
   include UIComponentHelper
 
-  describe "viewing the cart without stubbed session" do
-    let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true, charges_sales_tax: true) }
-    let(:supplier) { create(:supplier_enterprise) }
-    let!(:order_cycle) { create(:simple_order_cycle, suppliers: [supplier], distributors: [distributor], coordinator: create(:distributor_enterprise), variants: [product_fee.variants.first]) }
-    let(:product_fee) { create(:simple_product, supplier: supplier, price: 0.86, on_hand: 12) }
-    let(:address) { create(:address, firstname: "Foo", lastname: "Bar") }
-    let(:user) { create(:user, bill_address: address, ship_address: address) }
-    let(:order) { create(:order, order_cycle: order_cycle, distributor: distributor, user: user) }
-    let(:variant) { product_fee.variants.first }
-
-    before do
-      Spree::Config.set allow_backorders: false
-      quick_login_as user
-      add_product_to_cart order, product_fee, quantity: 10
-      # FIXME - this is required because of prepend_before_filters in orders controller redirects anyway because current_order or current_distributor is not set yet
-      visit spree.root_path
-    end
-
-    it "doesn't let to checkout with insufficient stock" do
-      visit spree.cart_path
-      expect(page).to have_content product_fee.name
-      expect(Spree::Config.allow_backorders).to be_false
-
-      variant.update_attributes! on_hand: 8
-      click_link "Checkout"
-      expect(page).to have_content 'Insufficient stock available, only 8 remaining'
-    end
-
-    it "doesn't let to checkout with insufficient stock after loggin back" do
-      visit spree.cart_path
-      expect(page).to have_content product_fee.name
-      expect(Spree::Config.allow_backorders).to be_false
-
-      logout
-      visit root_path
-      expect(page).not_to have_content "Shopping @ #{distributor.name.upcase}"
-      variant.update_attributes! on_hand: 5
-
-      quick_login_as user
-      # FIXME - this is required because of prepend_before_filters in orders controller redirects anyway because current_order or current_distributor is not set yet
-      visit root_path
-      expect(page).to have_content "Shopping @ #{distributor.name.upcase}"
-      visit spree.cart_path
-      expect(page).to have_content 'Insufficient stock available, only 5 remaining'
-    end
-
-  end
-
   describe "viewing the cart" do
     let!(:zone) { create(:zone_with_member) }
     let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true, charges_sales_tax: true) }
@@ -64,118 +16,160 @@ feature "full-page cart", js: true do
     let(:product_fee) { create(:simple_product, supplier: supplier, price: 0.86, on_hand: 100) }
     let(:order) { create(:order, order_cycle: order_cycle, distributor: distributor) }
 
-    context "with stubbed session" do
+    before do
+      set_order order
+    end
+
+    describe "fees" do
+      let(:percentage_fee) { create(:enterprise_fee, calculator: Calculator::FlatPercentPerItem.new(preferred_flat_percent: 20)) }
+
       before do
-        set_order_into_stubbed_session order
+        add_enterprise_fee percentage_fee
+        add_product_to_cart order, product_fee, quantity: 8
+        visit spree.cart_path
       end
 
-      describe "fees" do
-        let(:percentage_fee) { create(:enterprise_fee, calculator: Calculator::FlatPercentPerItem.new(preferred_flat_percent: 20)) }
+      it "rounds fee calculations correctly" do
+        # $0.86 + 20% = $1.032
+        # Fractional cents should be immediately rounded down and not carried through
+        sleep 10
+        save_screenshot '/Users/rob/Desktop/ss.png'
+        expect(page).to have_selector '.cart-item-price',         text: with_currency(1.03)
+        expect(page).to have_selector '.cart-item-total',         text: with_currency(8.24)
+        expect(page).to have_selector '.order-total.item-total',  text: with_currency(8.24)
+        expect(page).to have_selector '.order-total.grand-total', text: with_currency(8.24)
+      end
+    end
 
-        before do
-          add_enterprise_fee percentage_fee
-          add_product_to_cart order, product_fee, quantity: 8
-          visit spree.cart_path
-        end
-
-        it "rounds fee calculations correctly" do
-          # $0.86 + 20% = $1.032
-          # Fractional cents should be immediately rounded down and not carried through
-          expect(page).to have_selector '.cart-item-price',         text: with_currency(1.03)
-          expect(page).to have_selector '.cart-item-total',         text: with_currency(8.24)
-          expect(page).to have_selector '.order-total.item-total',  text: with_currency(8.24)
-          expect(page).to have_selector '.order-total.grand-total', text: with_currency(8.24)
-        end
+    describe "tax" do
+      before do
+        add_enterprise_fee enterprise_fee
+        add_product_to_cart order, product_tax
+        visit spree.cart_path
       end
 
-      describe "tax" do
-        before do
-          add_enterprise_fee enterprise_fee
-          add_product_to_cart order, product_tax
-          visit spree.cart_path
-        end
+      it "shows the total tax for the order, including product tax and tax on fees" do
+        page.should have_selector '.tax-total', text: '11.00' # 10 + 1
+      end
+    end
 
-        it "shows the total tax for the order, including product tax and tax on fees" do
-          page.should have_selector '.tax-total', text: '11.00' # 10 + 1
-        end
+    describe "updating quantities with insufficient stock available" do
+      let(:li) { order.line_items(true).last }
+      let(:variant) { product_tax.variants.first }
+
+      before do
+        add_product_to_cart order, product_tax
       end
 
-      describe "updating quantities with insufficient stock available" do
-        let(:li) { order.line_items(true).last }
-        let(:variant) { product_tax.variants.first }
+      it "prevents me from entering an invalid value" do
+        # Given we have 2 on hand, and we've loaded the page after that fact
+        variant.update_attributes! on_hand: 2
+        visit spree.cart_path
 
-        before do
-          add_product_to_cart order, product_tax
-        end
-
-        it "prevents me from entering an invalid value" do
-          # Given we have 2 on hand, and we've loaded the page after that fact
-          variant.update_attributes! on_hand: 2
-          visit spree.cart_path
-
-          accept_alert 'Insufficient stock available, only 2 remaining' do
-            fill_in "order_line_items_attributes_0_quantity", with: '4'
-          end
-
-          page.should have_field "order_line_items_attributes_0_quantity", with: '2'
-        end
-
-        it "shows the quantities saved, not those submitted" do
-          # Given we load the page with 3 on hand, then the number available drops to 2
-          visit spree.cart_path
-          variant.update_attributes! on_hand: 2
-
+        accept_alert 'Insufficient stock available, only 2 remaining' do
           fill_in "order_line_items_attributes_0_quantity", with: '4'
-
-          click_button 'Update'
-
-          page.should have_field "order[line_items_attributes][0][quantity]", with: '1'
-          page.should have_content "Insufficient stock available, only 2 remaining"
         end
+
+        page.should have_field "order_line_items_attributes_0_quantity", with: '2'
       end
 
-      context "when ordered in the same order cycle" do
-        let(:address) { create(:address) }
-        let(:user) { create(:user, bill_address: address, ship_address: address) }
-        let!(:prev_order1) { create(:completed_order_with_totals, order_cycle: order_cycle, distributor: distributor, user: user) }
-        let!(:prev_order2) { create(:completed_order_with_totals, order_cycle: order_cycle, distributor: distributor, user: user) }
+      it "shows the quantities saved, not those submitted" do
+        # Given we load the page with 3 on hand, then the number available drops to 2
+        visit spree.cart_path
+        variant.update_attributes! on_hand: 2
 
-        before do
-          order.user = user
-          order.save
-          order.distributor.allow_order_changes = true
-          order.distributor.save
-          add_product_to_cart order, product_tax
+        fill_in "order_line_items_attributes_0_quantity", with: '4'
+
+        click_button 'Update'
+
+        page.should have_field "order[line_items_attributes][0][quantity]", with: '1'
+        page.should have_content "Insufficient stock available, only 2 remaining"
+      end
+    end
+
+    context "when ordered in the same order cycle" do
+      let(:address) { create(:address) }
+      let(:user) { create(:user, bill_address: address, ship_address: address) }
+      let!(:prev_order1) { create(:completed_order_with_totals, order_cycle: order_cycle, distributor: distributor, user: user) }
+      let!(:prev_order2) { create(:completed_order_with_totals, order_cycle: order_cycle, distributor: distributor, user: user) }
+
+      before do
+        order.user = user
+        order.save
+        order.distributor.allow_order_changes = true
+        order.distributor.save
+        add_product_to_cart order, product_tax
+        quick_login_as user
+        visit spree.cart_path
+      end
+
+      it "shows already ordered line items" do
+        item1 = prev_order1.line_items.first
+        item2 = prev_order2.line_items.first
+
+        expect(page).to_not have_content item1.variant.name
+        expect(page).to_not have_content item2.variant.name
+
+        expect(page).to have_link I18n.t(:orders_bought_edit_button), href: spree.account_path
+        find("td.toggle-bought").click
+
+        expect(page).to have_content item1.variant.name
+        expect(page).to have_content item2.variant.name
+        page.find(".line-item-#{item1.id} td.bought-item-delete a").click
+        expect(page).to have_no_content item1.variant.name
+        expect(page).to have_content item2.variant.name
+
+        # open the dropdown cart and check there as well
+        find('#cart').click
+        expect(page).to have_no_content item1.variant.name
+        expect(page).to have_content item2.variant.name
+
+        visit spree.cart_path
+
+        find("td.toggle-bought").click
+        expect(page).to have_no_content item1.variant.name
+        expect(page).to have_content item2.variant.name
+      end
+    end
+
+    context "checking out with insufficient stock" do
+      let(:address) { create(:address, firstname: "Foo", lastname: "Bar") }
+      let(:user) { create(:user, bill_address: address, ship_address: address) }
+      let(:order) { create(:order, order_cycle: order_cycle, distributor: distributor, user: user) }
+      let(:variant) { product_fee.variants.first }
+
+      before do
+        Spree::Config.set allow_backorders: false
+        quick_login_as user
+        add_product_to_cart order, product_fee, quantity: 10
+      end
+
+      it "isn't allowed" do
+        visit spree.cart_path
+        expect(page).to have_content product_fee.name
+        expect(Spree::Config.allow_backorders).to be_false
+
+        variant.update_attributes! on_hand: 8
+        click_link "Checkout"
+        expect(page).to have_content 'Insufficient stock available, only 8 remaining'
+      end
+
+      context "after logging back in" do
+        it "still isn't allowed" do
+          visit spree.cart_path
+          expect(page).to have_content product_fee.name
+          expect(Spree::Config.allow_backorders).to be_false
+
+          logout
+          visit root_path
+          expect(page).not_to have_content "Shopping @ #{distributor.name.upcase}"
+          variant.update_attributes! on_hand: 5
+
           quick_login_as user
+          visit root_path
+          expect(page).to have_content "Shopping @ #{distributor.name.upcase}"
           visit spree.cart_path
-        end
-
-        it "shows already ordered line items" do
-          item1 = prev_order1.line_items.first
-          item2 = prev_order2.line_items.first
-
-          expect(page).to_not have_content item1.variant.name
-          expect(page).to_not have_content item2.variant.name
-
-          expect(page).to have_link I18n.t(:orders_bought_edit_button), href: spree.account_path
-          find("td.toggle-bought").click
-
-          expect(page).to have_content item1.variant.name
-          expect(page).to have_content item2.variant.name
-          page.find(".line-item-#{item1.id} td.bought-item-delete a").click
-          expect(page).to have_no_content item1.variant.name
-          expect(page).to have_content item2.variant.name
-
-          # open the dropdown cart and check there as well
-          find('#cart').click
-          expect(page).to have_no_content item1.variant.name
-          expect(page).to have_content item2.variant.name
-
-          visit spree.cart_path
-
-          find("td.toggle-bought").click
-          expect(page).to have_no_content item1.variant.name
-          expect(page).to have_content item2.variant.name
+          expect(page).to have_content 'Insufficient stock available, only 5 remaining'
         end
       end
     end

--- a/spec/features/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/features/consumer/shopping/checkout_auth_spec.rb
@@ -17,7 +17,7 @@ feature "As a consumer I want to check out my cart", js: true do
   after { Warden.test_reset! }
 
   before do
-    set_order_into_stubbed_session order
+    set_order order
     add_product_to_cart order, product
   end
 

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -21,7 +21,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
     Spree::Config.shipping_tax_rate = 0.25
 
     add_enterprise_fee enterprise_fee
-    set_order_into_stubbed_session order
+    set_order order
     add_product_to_cart order, product
   end
 

--- a/spec/features/consumer/shopping/products_spec.rb
+++ b/spec/features/consumer/shopping/products_spec.rb
@@ -16,7 +16,7 @@ feature "As a consumer I want to view products", js: true do
     let(:exchange1) { oc1.exchanges.to_enterprises(distributor).outgoing.first }
 
     before do
-      set_order_into_stubbed_session order
+      set_order order
     end
 
     describe "viewing HTML product descriptions" do

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -18,7 +18,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
     context "with stubbed session" do
       before do
-        set_order_into_stubbed_session order
+        set_order order
       end
 
       it "shows a distributor with images" do

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -105,15 +105,21 @@ describe Spree.user_class do
 
   describe "last incomplete spree order" do
     let(:user) { create(:user) }
-    let!(:order) { create(:order, state: 'cart', user_id: user.id) }
+    let!(:order) { create(:order, state: 'cart', user: user) }
 
-    it "returns any prior incomplete orders" do
-      expect(user.last_incomplete_spree_order).to eq order
+    context "where the user has no account invoices" do
+      it "returns any prior incomplete orders" do
+        expect(user.last_incomplete_spree_order).to eq order
+      end
     end
 
-    it "ignores prior orders linked to an account_invoice" do
-      create :account_invoice, user: user
-      expect(user.last_incomplete_spree_order).to be_nil
+    context "where the user as at least one account invoice" do
+      let(:account_invoice_order) { create(:order, state: 'cart', user: user) }
+      let(:account_invoice) { create(:account_invoice, user: user, order: account_invoice_order) }
+
+      it "ignores prior orders linked to an account invoice" do
+        expect(user.last_incomplete_spree_order).to eq order
+      end
     end
   end
 

--- a/spec/requests/shop_spec.rb
+++ b/spec/requests/shop_spec.rb
@@ -21,7 +21,7 @@ describe "Shop API" do
     let(:order) { create(:order, distributor: distributor, order_cycle: oc1) }
 
     before do
-      set_order_into_stubbed_session order
+      set_order order
 
       v61.update_attribute(:count_on_hand, 1)
       p6.delete

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -12,8 +12,8 @@ module ShopWorkflow
     order_cycle.exchanges.outgoing.first.enterprise_fees << enterprise_fee
   end
 
-  def set_order_into_stubbed_session(order)
-    ApplicationController.any_instance.stub(:session).and_return({order_id: order.id, access_token: order.token})
+  def set_order(order)
+    inject_session(order_id: order.id, access_token: order.token)
   end
 
   def add_product_to_cart(order, product, quantity: 1)
@@ -47,6 +47,14 @@ module ShopWorkflow
     if oc.exchanges.from_enterprise(supplier).incoming.empty?
       create(:exchange, order_cycle: oc, incoming: true,
                         sender: supplier, receiver: oc.coordinator)
+    end
+  end
+
+  def inject_session(hash)
+    Warden.on_next_request do |proxy|
+      hash.each do |key, value|
+        proxy.raw_session[key] = value
+      end
     end
   end
 end


### PR DESCRIPTION
- Fixed the model spec that was testing `last_incomplete_order`
- Used Warden to inject values directly into the session, rather than stubbing it. This was mainly because I didn't like the way the spec was being split up into sections based on whether the session was stubbed or not.